### PR TITLE
Fix plugin for new android versions (API 31 and above)

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -77,6 +77,5 @@
         </js-module>
     </platform>
     <dependency id="cordova-plugin-ionic-webview" version=">=2.1.4"/>
-    <dependency id="cordova-plugin-whitelist" version="^1.3.3"/>
     <author>Ionic</author>
 </plugin>

--- a/src/android/cordovapluginionic.gradle
+++ b/src/android/cordovapluginionic.gradle
@@ -3,7 +3,7 @@ repositories{
 }
 
 dependencies {
-   compile 'commons-io:commons-io:2.4'
+   implementation 'commons-io:commons-io:2.4'
 }
 
 android {


### PR DESCRIPTION
This PR fixes the plugin for the newest Android API. It does the following:
- Use `implementation` instead of compile, since the new gradle versions no longer support this and it is deprecated. [[ionic-team repo PR](https://github.com/ionic-team/cordova-plugin-ionic/pull/244)]
- Remove `whitlelist` dependency as it is no longer needed [[ionic-team repo PR](https://github.com/ionic-team/cordova-plugin-ionic/pull/245)]

As `implementation` is supported in older gradle versions, and the dependency for the `whitelist` plugin was added to make file-transfer work, but it was removed long ago, these changes shouldn't break older versions of our app.

Tested it on newer and older versions on an android device.